### PR TITLE
fix: função map dos selects na dashboard paciente

### DIFF
--- a/src/Pages/Dashboard Paciente/index.jsx
+++ b/src/Pages/Dashboard Paciente/index.jsx
@@ -119,7 +119,7 @@ const DashboardPaciente = () => {
             >
               {price.map(item => (
                 <option value={item} key={item}>
-                  {item.username}
+                  {item}
                 </option>
               ))}
             </Select>


### PR DESCRIPTION
Arrumei a função map dos selects, estava chamando a propriedade username, que não existia.